### PR TITLE
Messages が毎回複製されるバグ修正

### DIFF
--- a/src/sela/agents/main_agent.py
+++ b/src/sela/agents/main_agent.py
@@ -78,7 +78,7 @@ class MainAgent:
 
     def run(self, user_message: str) -> str:
         new_message = Message(text=user_message, role="human")
-        self.state.user_message = new_message
+        self.state = SeLaState(user_message=new_message)
         result = self.graph.invoke(self.state, self.checkpoint_conf)
         self.state = SeLaState(**result)
         return self.state

--- a/src/sela/main.py
+++ b/src/sela/main.py
@@ -8,7 +8,8 @@ if __name__ == "__main__":
     agent = MainAgent()
 
     response = agent.run("こんにちは")
-
     print(response.messages.messages[-1].text)
-    print(agent.state)
-    print(agent.state.messages)
+    response = agent.run("調子はどうですか？")
+    print(response.messages.messages[-1].text)
+    response = agent.run("さようなら")
+    print(response.messages.messages[-1].text)


### PR DESCRIPTION
- stategraph.invoke に checkoiunt の conf を渡して実行すると，「checkpoint の state で上書きして実行」という処理になる
- 上書きの際に Annotated[list, operator.add] していると，「今のstate に checkpoint の state を contcat して実行」になる
- 自前で state を管理していると，checkpointer で管理しているものと二重になり，実行ごとに複製されて行ってしまう
- stategraph.invoke に渡す state は毎回初期化するようにすることで解決